### PR TITLE
Fix launcher not working with space in path

### DIFF
--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -16,6 +16,7 @@ def run():
     jar_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "openapi-generator.jar"
     )
+    jar_path = "\"" + jar_path + "\""
     arguments.append(jar_path)
 
     if len(sys.argv) > 1:


### PR DESCRIPTION
If the launcher is located in a directory with a path that contains a space (e.g. `C:\Users\SomeUser\Dir With Space\venv\Lib\site-packages\openapi_generator_cli`) the call to the jar would fail:
`Error: Unable to access jarfile C:\Users\SomeUser\Dir`
Fixed the issue by surrounding jar_path with double quotes.