### PR TITLE
Fix substitution for package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 ]
 
 [tool.poetry]
-version = "7.10.0"
+version = "0"
 authors = [
   "OpenAPI Generator community <team@openapitools.org>",
 ]


### PR DESCRIPTION
I have fixed an error in `publish.py`. 

When multiple versions were released in succession, with no replacement after the first replacement.

Example:
1. 1.2.3: `version = "0"` → `version = "1.2.3"`
1. 1.2.4: `version = "1.2.3"` → `version = "1.2.3"`
1. 1.2.5: `version = "1.2.3"` → `version = "1.2.3"`
...