### PR TITLE
Include openapi-generator.jar even in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ requires-poetry = ">=2.0"
 packages = [
   { include = "openapi_generator_cli" },
 ]
-include = [ "openapi_generator_cli/*.jar" ]
+include = [
+  { path = "openapi_generator_cli/openapi-generator.jar", format = [ "sdist", "wheel" ] },
+]
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=0.991,<1.15"


### PR DESCRIPTION
fixes: #25 

Poetry will only include files in the `sdist` file if `format` is not specified in `tools.poetry.include`.

So I added a setting to the `format` field to include `openapi-generator.jar` in both `sdist` (`.tar.gz`) and `wheel` (`.whl`).

ref:
https://python-poetry.org/docs/pyproject/#exclude-and-include
> If no format is specified, include defaults to only sdist.
> In contrast, exclude defaults to both sdist and wheel.

Test release in TestPyPI:
https://test.pypi.org/project/openapi-generator-cli/7.11.0.post0

<details>

<summary>

Confirmed that `openapi-generator.jar` included in both `.whl` and `.tar.gz` when build distribution files by running `poetry build`.

</summary>

```shellsession
$ poetry publish -r testpypi -v --build
Trying to detect current active python executable as specified in the config.
Found: /home/eggplants/.pyenv/versions/3.12.3/bin/python
Using virtualenv: /home/eggplants/.cache/pypoetry/virtualenvs/openapi-generator-cli-XnyH23gs-py3.12
Building openapi-generator-cli (7.11.0.post0)
  - Building sdist
  - Built openapi_generator_cli-7.11.0.post0.tar.gz
  - Building wheel
  - Built openapi_generator_cli-7.11.0.post0-py3-none-any.whl

Publishing openapi-generator-cli (7.11.0.post0) to testpypi
 - Uploading openapi_generator_cli-7.11.0.post0-py3-none-any.whl 100%
 - Uploading openapi_generator_cli-7.11.0.post0.tar.gz 100%
$ wget https://test-files.pythonhosted.org/packages/4f/6e/f8405c01825418b069785e3ad4fefa63b5800bc9f6fc230fc438a655a6e4/openapi_generator_cli-7.11.0.post0.tar.gz
--2025-01-23 00:11:43--  https://test-files.pythonhosted.org/packages/4f/6e/f8405c01825418b069785e3ad4fefa63b5800bc9f6fc230fc438a655a6e4/openapi_generator_cli-7.11.0.post0.tar.gz
Resolving test-files.pythonhosted.org (test-files.pythonhosted.org)... 146.75.112.223, 2a04:4e42:8c::223
Connecting to test-files.pythonhosted.org (test-files.pythonhosted.org)|146.75.112.223|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 27099669 (26M) [application/octet-stream]
Saving to: ‘openapi_generator_cli-7.11.0.post0.tar.gz’

openapi_generator_cli-7.11.0.post 100%[===========================================================>]  25.84M  3.37MB/s    in 7.9s

2025-01-23 00:11:51 (3.27 MB/s) - ‘openapi_generator_cli-7.11.0.post0.tar.gz’ saved [27099669/27099669]

$ wget https://test-files.pythonhosted.org/packages/0d/f2/468a4905aad315ad206bf5a1e3ec9295bad75bde1a04aa6095cda9456762/openapi_generator_cli-7.11.0.post0-py3-none-any.whl
--2025-01-23 00:11:57--  https://test-files.pythonhosted.org/packages/0d/f2/468a4905aad315ad206bf5a1e3ec9295bad75bde1a04aa6095cda9456762/openapi_generator_cli-7.11.0.post0-py3-none-any.whl
Resolving test-files.pythonhosted.org (test-files.pythonhosted.org)... 146.75.112.223, 2a04:4e42:8c::223
Connecting to test-files.pythonhosted.org (test-files.pythonhosted.org)|146.75.112.223|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 27113147 (26M) [application/octet-stream]
Saving to: ‘openapi_generator_cli-7.11.0.post0-py3-none-any.whl’

openapi_generator_cli-7.11.0.post 100%[===========================================================>]  25.86M  3.01MB/s    in 8.7s

2025-01-23 00:12:06 (2.97 MB/s) - ‘openapi_generator_cli-7.11.0.post0-py3-none-any.whl’ saved [27113147/27113147]
```

```shellsession
$ tar -tvf openapi_generator_cli-7.11.0.post0.tar.gz
-rw-r--r-- 0/0           11357 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/LICENSE
-rw-r--r-- 0/0            2634 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/README.md
-rw-r--r-- 0/0            1634 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/openapi_generator_cli/__init__.py
-rw-r--r-- 0/0        30291831 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/openapi_generator_cli/openapi-generator.jar
-rw-r--r-- 0/0               0 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/openapi_generator_cli/py.typed
-rw-r--r-- 0/0            2541 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/pyproject.toml
-rw-r--r-- 0/0            3850 1970-01-01 09:00 openapi_generator_cli-7.11.0.post0/PKG-INFO
```

```shellsession
$ unzip -l openapi_generator_cli-7.11.0.post0-py3-none-any.whl
Archive:  openapi_generator_cli-7.11.0.post0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     1634  2016-01-01 00:00   openapi_generator_cli/__init__.py
 30291831  2016-01-01 00:00   openapi_generator_cli/openapi-generator.jar
        0  2016-01-01 00:00   openapi_generator_cli/py.typed
    11357  2016-01-01 00:00   openapi_generator_cli-7.11.0.post0.dist-info/LICENSE
     3850  2016-01-01 00:00   openapi_generator_cli-7.11.0.post0.dist-info/METADATA
       88  2016-01-01 00:00   openapi_generator_cli-7.11.0.post0.dist-info/WHEEL
       67  2016-01-01 00:00   openapi_generator_cli-7.11.0.post0.dist-info/entry_points.txt
      773  2016-01-01 00:00   openapi_generator_cli-7.11.0.post0.dist-info/RECORD
---------                     -------
 30309600                     8 files
```

</details>