### PR TITLE
Propagate CLI subprocess exit code

### DIFF
--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -58,7 +58,10 @@ def run(args: list[str] | None = None) -> subprocess.CompletedProcess[bytes]:
 
 def cli(argv: list[str] | None = None) -> None:
     """Run the OpenAPI Generator CLI with the arguments provided on the command line."""
-    args = argv[1:] if argv is not None and len(argv) > 1 else []
+    argv = argv or sys.argv
+    args = []
+    if len(argv) > 1:
+        args = argv[1:]
     sys.exit(run(args).returncode)
 
 

--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -58,12 +58,9 @@ def run(args: list[str] | None = None) -> subprocess.CompletedProcess[bytes]:
 
 def cli(argv: list[str] | None = None) -> None:
     """Run the OpenAPI Generator CLI with the arguments provided on the command line."""
-    argv = argv or sys.argv
-    args = []
-    if len(argv) > 1:
-        args = argv[1:]
+    args = (argv or sys.argv)[1:]
     sys.exit(run(args).returncode)
 
 
 if __name__ == "__main__":
-    cli(sys.argv)
+    cli()

--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -61,7 +61,7 @@ def cli() -> None:
     args = []
     if len(sys.argv) > 1:
         args = sys.argv[1:]
-    run(args)
+    sys.exit(run(args).returncode)
 
 
 if __name__ == "__main__":

--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -56,13 +56,11 @@ def run(args: list[str] | None = None) -> subprocess.CompletedProcess[bytes]:
     return subprocess.run(arguments, check=False)  # noqa: S603
 
 
-def cli() -> None:
+def cli(argv: list[str] | None = None) -> None:
     """Run the OpenAPI Generator CLI with the arguments provided on the command line."""
-    args = []
-    if len(sys.argv) > 1:
-        args = sys.argv[1:]
+    args = argv[1:] if argv is not None and len(argv) > 1 else []
     sys.exit(run(args).returncode)
 
 
 if __name__ == "__main__":
-    cli()
+    cli(sys.argv)

--- a/openapi_generator_cli/__init__.py
+++ b/openapi_generator_cli/__init__.py
@@ -57,7 +57,14 @@ def run(args: list[str] | None = None) -> subprocess.CompletedProcess[bytes]:
 
 
 def cli(argv: list[str] | None = None) -> None:
-    """Run the OpenAPI Generator CLI with the arguments provided on the command line."""
+    """Run the OpenAPI Generator CLI with the arguments provided on the command line.
+
+    Args:
+        argv (list[str], optional):
+            The command-line arguments to pass to the OpenAPI Generator CLI.
+            If not provided, sys.argv is used.
+
+    """
     args = (argv or sys.argv)[1:]
     sys.exit(run(args).returncode)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 from openapi_generator_cli import cli, run
-
-RETURN_CODE = 23
 
 
 def test_cli_version(capfd: pytest.CaptureFixture[str]) -> None:
@@ -49,14 +45,14 @@ def test_invalid_arg(capfd: pytest.CaptureFixture[str]) -> None:
     )
 
 
-@patch("openapi_generator_cli.run", autospec=True)
-@patch("sys.argv", ["openapi-generator-cli", "version"])
-def test_cli_exits_with_returncode(run_mock: MagicMock) -> None:
-    run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=RETURN_CODE)
-
+def test_cli_invalid_arg(capfd: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc_info:
-        cli()
+        cli(["openapi-generator-cli", "--invalid-arg-404"])
+    assert exc_info.value.code == 1
 
-    assert exc_info.value.code == RETURN_CODE
-
-    run_mock.assert_called_once_with(["version"])
+    captured = capfd.readouterr()
+    assert not captured.out
+    assert (
+        "Found unexpected parameters: [--invalid-arg-404]"
+        in captured.err.split(os.linesep)[0]
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import re
-from typing import TYPE_CHECKING
+import subprocess
+from unittest.mock import MagicMock, patch
 
-from openapi_generator_cli import run
+import pytest
 
-if TYPE_CHECKING:
-    import pytest
+from openapi_generator_cli import cli, run
+
+RETURN_CODE = 23
 
 
 def test_cli_version(capfd: pytest.CaptureFixture[str]) -> None:
@@ -45,3 +47,16 @@ def test_invalid_arg(capfd: pytest.CaptureFixture[str]) -> None:
         "Found unexpected parameters: [--invalid-arg-404]"
         in captured.err.split(os.linesep)[0]
     )
+
+
+@patch("openapi_generator_cli.run", autospec=True)
+@patch("sys.argv", ["openapi-generator-cli", "version"])
+def test_cli_exits_with_returncode(run_mock: MagicMock) -> None:
+    run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=RETURN_CODE)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli()
+
+    assert exc_info.value.code == RETURN_CODE
+
+    run_mock.assert_called_once_with(["version"])


### PR DESCRIPTION
#### Problem
The console script currently discards the return code from the Java subprocess. That means callers can see a successful Python CLI exit even when Java fails.

#### Solution
Exit from the console entry point with the subprocess return code. Add a regression test that verifies the CLI propagates a non-zero result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagate the Java subprocess exit code from the `openapi-generator-cli` entrypoint so callers and CI fail correctly. `cli` now accepts `argv` and defaults to `sys.argv` to preserve behavior and simplify testing.

- **Bug Fixes**
  - Exit with the Java return code via `sys.exit(run(args).returncode)` and parse args as `(argv or sys.argv)[1:]`.
  - Add tests for `run([...])` and `cli([...])` to assert non-zero exit codes, error message, and no stdout on invalid args.
  - Document the `cli(argv)` argument and default behavior in the docstring.

<sup>Written for commit 44495ecc0169c3dc6b0d3230efb8510d125d1551. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-pip/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

